### PR TITLE
Chore: Exclude redux modules from CodeClimate duplication check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,9 @@
+engines:
+  eslint:
+    enabled: true
+
+  duplication:
+    enabled: true
+    exclude_paths:
+    - "redux/modules"
+    - "redux/selectors"


### PR DESCRIPTION
- Added `.codeclimate.yml` config file with `eslint` and `duplication` engines
- Excluded redux `modules` and `selectors` from duplication check